### PR TITLE
Add type annotations to make tsc works.

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -407,6 +407,7 @@ function _fetchDocument(worker, source, pdfDataRangeTransport, docId) {
     });
 }
 
+/** @type {Object} */
 const PDFDocumentLoadingTask = (function PDFDocumentLoadingTaskClosure() {
   let nextDocumentId = 0;
 
@@ -1563,6 +1564,7 @@ class LoopbackPort {
  *   constants from {VerbosityLevel} should be used.
  */
 
+ /** @type {Object} */
 const PDFWorker = (function PDFWorkerClosure() {
   const pdfWorkerPorts = new WeakMap();
   let isWorkerDisabled = false;

--- a/src/display/canvas.js
+++ b/src/display/canvas.js
@@ -434,6 +434,7 @@ var CanvasExtraState = (function CanvasExtraStateClosure() {
   return CanvasExtraState;
 })();
 
+/** @type {Object} */
 var CanvasGraphics = (function CanvasGraphicsClosure() {
   // Defines the time the executeOperatorList is going to be executing
   // before it stops and shedules a continue of execution.

--- a/src/display/pattern_helper.js
+++ b/src/display/pattern_helper.js
@@ -380,6 +380,7 @@ function getShadingPatternFromIR(raw) {
   return shadingIR.fromIR(raw);
 }
 
+/** @type {Object} */
 var TilingPattern = (function TilingPatternClosure() {
   var PaintType = {
     COLORED: 1,

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -404,6 +404,7 @@ function shadow(obj, prop, value) {
   return value;
 }
 
+/** @type {Error} */
 const BaseException = (function BaseExceptionClosure() {
   function BaseException(message) {
     if (this.constructor === BaseException) {


### PR DESCRIPTION
With this PR, I can run `npx tsc -p .`,  and `*.d.ts` files are generated.
```
$  ll build/tsc-out/display 
total 792
-rw-r--r--  1 tamura  staff    33K  2 13 18:12 api.d.ts
-rw-r--r--  1 tamura  staff    97K  2 13 18:12 api.js
-rw-r--r--  1 tamura  staff    40B  2 13 18:12 api_compatibility.d.ts
-rw-r--r--  1 tamura  staff   1.7K  2 13 18:12 api_compatibility.js
-rw-r--r--  1 tamura  staff    57B  2 13 18:12 canvas.d.ts
-rw-r--r--  1 tamura  staff    86K  2 13 18:12 canvas.js
-rw-r--r--  1 tamura  staff   7.6K  2 13 18:12 display_utils.d.ts
-rw-r--r--  1 tamura  staff    20K  2 13 18:12 display_utils.js
-rw-r--r--  1 tamura  staff   693B  2 13 18:12 font_loader.d.ts
-rw-r--r--  1 tamura  staff    18K  2 13 18:12 font_loader.js
-rw-r--r--  1 tamura  staff   212B  2 13 18:12 metadata.d.ts
-rw-r--r--  1 tamura  staff   4.1K  2 13 18:12 metadata.js
-rw-r--r--  1 tamura  staff   112B  2 13 18:12 pattern_helper.d.ts
-rw-r--r--  1 tamura  staff    18K  2 13 18:12 pattern_helper.js
-rw-r--r--  1 tamura  staff   1.7K  2 13 18:12 transport_stream.d.ts
-rw-r--r--  1 tamura  staff   8.3K  2 13 18:12 transport_stream.js
-rw-r--r--  1 tamura  staff   499B  2 13 18:12 webgl.d.ts
-rw-r--r--  1 tamura  staff    19K  2 13 18:12 webgl.js
-rw-r--r--  1 tamura  staff    39B  2 13 18:12 worker_options.d.ts
-rw-r--r--  1 tamura  staff   1.4K  2 13 18:12 worker_options.js
-rw-r--r--  1 tamura  staff   974B  2 13 18:12 xml_parser.d.ts
-rw-r--r--  1 tamura  staff    12K  2 13 18:12 xml_parser.js
```